### PR TITLE
Add owner controls for room setupAdd owner controls for room setup

### DIFF
--- a/backend/src/main/java/com/puzzleroom/room/Room.java
+++ b/backend/src/main/java/com/puzzleroom/room/Room.java
@@ -33,6 +33,9 @@ public class Room {
     @Column(nullable = false, unique = true, length = 20)
     private String inviteCode;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean locked = false;
+
     @Column(nullable = false)
     private int maxMembers = MAX_MEMBERS;
 
@@ -59,12 +62,16 @@ public class Room {
     public RoomStatus getStatus() { return status; }
     public Puzzle getPuzzle() { return puzzle; }
     public String getInviteCode() { return inviteCode; }
+    public boolean isLocked() { return locked; }
     public int getMaxMembers() { return maxMembers; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getStartedAt() { return startedAt; }
     public Instant getCompletedAt() { return completedAt; }
 
     public void setStatus(RoomStatus status) { this.status = status; }
+    public void setInviteCode(String inviteCode) { this.inviteCode = inviteCode; }
+    public void setLocked(boolean locked) { this.locked = locked; }
+    public void setMaxMembers(int maxMembers) { this.maxMembers = maxMembers; }
     public void setStartedAt(Instant startedAt) { this.startedAt = startedAt; }
     public void setCompletedAt(Instant completedAt) { this.completedAt = completedAt; }
 }

--- a/backend/src/main/java/com/puzzleroom/room/RoomController.java
+++ b/backend/src/main/java/com/puzzleroom/room/RoomController.java
@@ -4,6 +4,8 @@ import com.puzzleroom.room.dto.CreateRoomRequest;
 import com.puzzleroom.room.dto.JoinRoomRequest;
 import com.puzzleroom.room.dto.RoomResponse;
 import com.puzzleroom.room.dto.RoomTaskResponse;
+import com.puzzleroom.room.dto.UpdateReadyRequest;
+import com.puzzleroom.room.dto.UpdateRoomSettingsRequest;
 import jakarta.validation.Valid;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +45,42 @@ public class RoomController {
     public List<RoomTaskResponse> start(@PathVariable UUID roomId, Authentication auth) {
         UUID userId = UUID.fromString(auth.getName());
         return rooms.startRoom(roomId, userId);
+    }
+
+    @PatchMapping("/{roomId}/settings")
+    public RoomResponse settings(
+            @PathVariable UUID roomId,
+            @Valid @RequestBody UpdateRoomSettingsRequest req,
+            Authentication auth
+    ) {
+        UUID userId = UUID.fromString(auth.getName());
+        return rooms.updateSettings(roomId, userId, req.locked, req.maxMembers);
+    }
+
+    @PostMapping("/{roomId}/invite-code/regenerate")
+    public RoomResponse regenerateInviteCode(@PathVariable UUID roomId, Authentication auth) {
+        UUID userId = UUID.fromString(auth.getName());
+        return rooms.regenerateInviteCode(roomId, userId);
+    }
+
+    @DeleteMapping("/{roomId}/members/{memberUserId}")
+    public RoomResponse removeMember(
+            @PathVariable UUID roomId,
+            @PathVariable UUID memberUserId,
+            Authentication auth
+    ) {
+        UUID userId = UUID.fromString(auth.getName());
+        return rooms.removeMember(roomId, memberUserId, userId);
+    }
+
+    @PatchMapping("/{roomId}/ready")
+    public RoomResponse ready(
+            @PathVariable UUID roomId,
+            @Valid @RequestBody UpdateReadyRequest req,
+            Authentication auth
+    ) {
+        UUID userId = UUID.fromString(auth.getName());
+        return rooms.updateReady(roomId, userId, req.ready);
     }
 
     @GetMapping("/{roomId}/tasks")

--- a/backend/src/main/java/com/puzzleroom/room/RoomMember.java
+++ b/backend/src/main/java/com/puzzleroom/room/RoomMember.java
@@ -28,6 +28,9 @@ public class RoomMember {
     @Column(nullable = false, length = 20)
     private RoomRole role;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean ready = false;
+
     @Column(nullable = false, updatable = false)
     private Instant joinedAt = Instant.now();
 
@@ -43,5 +46,8 @@ public class RoomMember {
     public Room getRoom() { return room; }
     public User getUser() { return user; }
     public RoomRole getRole() { return role; }
+    public boolean isReady() { return ready; }
     public Instant getJoinedAt() { return joinedAt; }
+
+    public void setReady(boolean ready) { this.ready = ready; }
 }

--- a/backend/src/main/java/com/puzzleroom/room/RoomService.java
+++ b/backend/src/main/java/com/puzzleroom/room/RoomService.java
@@ -85,6 +85,9 @@ public class RoomService {
         if (members.findByRoomIdAndUserId(room.getId(), userId).isPresent()) {
             return buildRoomResponse(room);
         }
+        if (room.isLocked()) {
+            throw new IllegalArgumentException("room is locked");
+        }
 
         long count = members.countByRoomId(room.getId());
         if (count >= room.getMaxMembers()) {
@@ -117,6 +120,9 @@ public class RoomService {
         if (roomMembers.isEmpty()) {
             throw new IllegalArgumentException("at least one participant required");
         }
+        if (!allMembersReady(roomMembers)) {
+            throw new IllegalArgumentException("all participants must be ready before starting");
+        }
 
         List<PuzzleTask> tasks = puzzleTasks.findByPuzzleIdOrderByOrderIndexAsc(room.getPuzzle().getId());
         if (tasks.size() < roomMembers.size()) {
@@ -143,6 +149,62 @@ public class RoomService {
         return created.stream()
                 .map(rt -> RoomTaskResponse.from(rt, durationSeconds(room, rt)))
                 .collect(Collectors.toList());
+    }
+
+    public RoomResponse updateSettings(UUID roomId, UUID userId, boolean locked, int maxMembers) {
+        Room room = requireOpenOwnedRoom(roomId, userId);
+        long currentMembers = members.countByRoomId(roomId);
+        if (maxMembers < currentMembers) {
+            throw new IllegalArgumentException("max members cannot be lower than current participants");
+        }
+        if (maxMembers < 2 || maxMembers > Room.MAX_MEMBERS) {
+            throw new IllegalArgumentException("max members must be between 2 and 4");
+        }
+
+        room.setLocked(locked);
+        room.setMaxMembers(maxMembers);
+        rooms.save(room);
+
+        events.roomUpdated(room.getId());
+        return buildRoomResponse(room);
+    }
+
+    public RoomResponse regenerateInviteCode(UUID roomId, UUID userId) {
+        Room room = requireOpenOwnedRoom(roomId, userId);
+        room.setInviteCode(generateInviteCode());
+        rooms.save(room);
+
+        events.roomUpdated(room.getId());
+        return buildRoomResponse(room);
+    }
+
+    public RoomResponse removeMember(UUID roomId, UUID memberUserId, UUID ownerId) {
+        Room room = requireOpenOwnedRoom(roomId, ownerId);
+        if (room.getOwnerId().equals(memberUserId)) {
+            throw new IllegalArgumentException("owner cannot be removed");
+        }
+
+        RoomMember member = members.findByRoomIdAndUserId(roomId, memberUserId)
+                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+        members.delete(member);
+
+        events.roomUpdated(room.getId());
+        return buildRoomResponse(room);
+    }
+
+    public RoomResponse updateReady(UUID roomId, UUID userId, boolean ready) {
+        Room room = requireRoom(roomId);
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new IllegalArgumentException("room already started");
+        }
+
+        RoomMember member = members.findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("not a room member"));
+        member.setReady(ready);
+        members.save(member);
+
+        events.roomUpdated(room.getId());
+        return buildRoomResponse(room);
     }
 
     public List<RoomTaskResponse> listTasks(UUID roomId, UUID userId) {
@@ -185,6 +247,17 @@ public class RoomService {
                 .orElseThrow(() -> new IllegalArgumentException("room not found"));
     }
 
+    private Room requireOpenOwnedRoom(UUID roomId, UUID ownerId) {
+        Room room = requireRoom(roomId);
+        if (!room.getOwnerId().equals(ownerId)) {
+            throw new IllegalArgumentException("only the owner can manage the room");
+        }
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new IllegalArgumentException("room already started");
+        }
+        return room;
+    }
+
     private User requireUser(UUID userId) {
         return users.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("user not found"));
@@ -215,7 +288,16 @@ public class RoomService {
                 .collect(Collectors.toList());
 
         Long teamTime = computeTeamTimeSeconds(room);
-        return RoomResponse.from(room, memberResponses, teamTime);
+        return RoomResponse.from(room, memberResponses, teamTime, allMembersReady(memberResponses));
+    }
+
+    private boolean allMembersReady(List<?> roomMembers) {
+        if (roomMembers.isEmpty()) return false;
+        for (Object item : roomMembers) {
+            if (item instanceof RoomMember member && !member.isReady()) return false;
+            if (item instanceof MemberResponse member && !member.ready) return false;
+        }
+        return true;
     }
 
     private Long computeTeamTimeSeconds(Room room) {

--- a/backend/src/main/java/com/puzzleroom/room/dto/MemberResponse.java
+++ b/backend/src/main/java/com/puzzleroom/room/dto/MemberResponse.java
@@ -7,12 +7,14 @@ public class MemberResponse {
     public UUID id;
     public String username;
     public String role;
+    public boolean ready;
 
     public static MemberResponse from(RoomMember m) {
         MemberResponse r = new MemberResponse();
         r.id = m.getUser().getId();
         r.username = m.getUser().getUsername();
         r.role = m.getRole().name();
+        r.ready = m.isReady();
         return r;
     }
 }

--- a/backend/src/main/java/com/puzzleroom/room/dto/RoomResponse.java
+++ b/backend/src/main/java/com/puzzleroom/room/dto/RoomResponse.java
@@ -13,27 +13,31 @@ public class RoomResponse {
     public boolean ownerParticipates;
     public RoomStatus status;
     public String inviteCode;
+    public boolean locked;
     public int maxMembers;
     public Instant createdAt;
     public Instant startedAt;
     public Instant completedAt;
     public Long teamTimeSeconds;
+    public boolean allMembersReady;
 
     public PuzzleInfo puzzle;
     public List<MemberResponse> members;
 
-    public static RoomResponse from(Room room, List<MemberResponse> members, Long teamTimeSeconds) {
+    public static RoomResponse from(Room room, List<MemberResponse> members, Long teamTimeSeconds, boolean allMembersReady) {
         RoomResponse r = new RoomResponse();
         r.id = room.getId();
         r.ownerId = room.getOwnerId();
         r.ownerParticipates = room.isOwnerParticipates();
         r.status = room.getStatus();
         r.inviteCode = room.getInviteCode();
+        r.locked = room.isLocked();
         r.maxMembers = room.getMaxMembers();
         r.createdAt = room.getCreatedAt();
         r.startedAt = room.getStartedAt();
         r.completedAt = room.getCompletedAt();
         r.teamTimeSeconds = teamTimeSeconds;
+        r.allMembersReady = allMembersReady;
         r.puzzle = PuzzleInfo.from(room);
         r.members = members;
         return r;

--- a/backend/src/main/java/com/puzzleroom/room/dto/UpdateReadyRequest.java
+++ b/backend/src/main/java/com/puzzleroom/room/dto/UpdateReadyRequest.java
@@ -1,0 +1,8 @@
+package com.puzzleroom.room.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class UpdateReadyRequest {
+    @NotNull
+    public Boolean ready;
+}

--- a/backend/src/main/java/com/puzzleroom/room/dto/UpdateRoomSettingsRequest.java
+++ b/backend/src/main/java/com/puzzleroom/room/dto/UpdateRoomSettingsRequest.java
@@ -1,0 +1,15 @@
+package com.puzzleroom.room.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public class UpdateRoomSettingsRequest {
+    @NotNull
+    public Boolean locked;
+
+    @NotNull
+    @Min(2)
+    @Max(4)
+    public Integer maxMembers;
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -104,7 +104,7 @@ export default function HomePage() {
           <div className="pill-grid">
             {genres.length === 0 && <span className="pill">Loading...</span>}
             {genres.map(([genre, count]) => (
-              <span key={genre} className="pill">{genre} · {count}</span>
+              <span key={genre} className="pill">{genre} | {count}</span>
             ))}
           </div>
           <div className="divider" />
@@ -116,18 +116,18 @@ export default function HomePage() {
       </section>
 
       {loading ? (
-        <div className="card">Loading your account…</div>
+        <div className="card">Loading your account...</div>
       ) : token ? (
         <section className="grid">
           <div className="card sticker tilt-left">
             <h2>Create a room</h2>
-            <p className="muted">Pick a puzzle. Decide if you’re playing.</p>
+            <p className="muted">Pick a puzzle. Decide if you're playing.</p>
             <form className="form" onSubmit={handleCreate}>
               <label>
                 Puzzle
                 <select value={puzzleId} onChange={(e) => setPuzzleId(e.target.value)} required>
                   {puzzles.map((p) => (
-                    <option key={p.id} value={p.id}>{p.title} · {p.genre}</option>
+                    <option key={p.id} value={p.id}>{p.title} | {p.genre}</option>
                   ))}
                 </select>
               </label>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -46,7 +46,7 @@ export default function LoginPage() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
+              placeholder="********"
               required
             />
           </label>

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -4,7 +4,7 @@ import { apiFetch } from "../api/client";
 import { useAuth } from "../auth/useAuth";
 
 function formatDuration(seconds) {
-  if (seconds == null) return "—";
+  if (seconds == null) return "-";
   const mins = Math.floor(seconds / 60);
   const secs = seconds % 60;
   return `${mins}m ${secs}s`;
@@ -19,6 +19,7 @@ export default function RoomPage() {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [settings, setSettings] = useState({ locked: false, maxMembers: 4 });
   const refreshInFlight = useRef(false);
 
   async function refresh({ silent = false } = {}) {
@@ -46,6 +47,14 @@ export default function RoomPage() {
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [roomId, token]);
+
+  useEffect(() => {
+    if (!room) return;
+    setSettings({
+      locked: Boolean(room.locked),
+      maxMembers: room.maxMembers || 4,
+    });
+  }, [room]);
 
   useEffect(() => {
     if (!token) return;
@@ -82,6 +91,77 @@ export default function RoomPage() {
       await refresh();
     } catch (err) {
       setError(err.message || "Failed to start room");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSaveSettings(e) {
+    e.preventDefault();
+    if (!token) return;
+    setBusy(true);
+    setError("");
+    try {
+      const nextRoom = await apiFetch(`/rooms/${roomId}/settings`, {
+        method: "PATCH",
+        token,
+        body: JSON.stringify(settings),
+      });
+      setRoom(nextRoom);
+    } catch (err) {
+      setError(err.message || "Failed to update room settings");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRegenerateInvite() {
+    if (!token) return;
+    setBusy(true);
+    setError("");
+    try {
+      const nextRoom = await apiFetch(`/rooms/${roomId}/invite-code/regenerate`, {
+        method: "POST",
+        token,
+      });
+      setRoom(nextRoom);
+    } catch (err) {
+      setError(err.message || "Failed to regenerate invite code");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRemoveMember(memberId) {
+    if (!token) return;
+    setBusy(true);
+    setError("");
+    try {
+      const nextRoom = await apiFetch(`/rooms/${roomId}/members/${memberId}`, {
+        method: "DELETE",
+        token,
+      });
+      setRoom(nextRoom);
+    } catch (err) {
+      setError(err.message || "Failed to remove participant");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleReady(ready) {
+    if (!token) return;
+    setBusy(true);
+    setError("");
+    try {
+      const nextRoom = await apiFetch(`/rooms/${roomId}/ready`, {
+        method: "PATCH",
+        token,
+        body: JSON.stringify({ ready }),
+      });
+      setRoom(nextRoom);
+    } catch (err) {
+      setError(err.message || "Failed to update ready status");
     } finally {
       setBusy(false);
     }
@@ -143,10 +223,17 @@ export default function RoomPage() {
     return { total, done, percent };
   }, [room?.members, memberStatus]);
 
+  const myMember = useMemo(() => {
+    if (!room || !me) return null;
+    return room.members?.find((member) => member.id === me.id) || null;
+  }, [room, me]);
+
+  const canStart = room?.status === "OPEN" && room?.allMembersReady;
+
   if (loading) {
     return (
       <div className="page">
-        <div className="card">Loading room…</div>
+        <div className="card">Loading room...</div>
       </div>
     );
   }
@@ -165,7 +252,7 @@ export default function RoomPage() {
         <div>
           <p className="eyebrow">Room {room.id}</p>
           <h1>{room.puzzle?.title}</h1>
-          <p className="muted">{room.puzzle?.genre} · Status: {room.status}</p>
+          <p className="muted">{room.puzzle?.genre} | Status: {room.status}</p>
         </div>
         <div className="room-meta">
           <div className="stat">
@@ -175,6 +262,10 @@ export default function RoomPage() {
           <div className="stat">
             <span className="label">Team time</span>
             <span className="value">{formatDuration(room.teamTimeSeconds)}</span>
+          </div>
+          <div className="stat">
+            <span className="label">Room</span>
+            <span className="value">{room.locked ? "Locked" : `${room.members?.length || 0}/${room.maxMembers}`}</span>
           </div>
         </div>
       </section>
@@ -234,8 +325,13 @@ export default function RoomPage() {
               >
                 <div>
                   <div className="strong">@{m.username}</div>
-                  <div className="muted small">{m.role}</div>
+                  <div className="muted small">{m.role} | {m.ready ? "Ready" : "Not ready"}</div>
                 </div>
+                {isOwner && room.status === "OPEN" && m.role !== "OWNER" && (
+                  <button className="ghost danger" onClick={() => handleRemoveMember(m.id)} disabled={busy}>
+                    Remove
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -248,12 +344,55 @@ export default function RoomPage() {
               </div>
             </div>
           )}
-          {isOwner && room.status === "OPEN" && (
-            <button className="primary" onClick={handleStart} disabled={busy}>
-              {busy ? "Starting..." : "Start room"}
+          {myMember && room.status === "OPEN" && (
+            <button className={myMember.ready ? "ghost" : "primary"} onClick={() => handleReady(!myMember.ready)} disabled={busy}>
+              {myMember.ready ? "Mark not ready" : "I'm ready"}
             </button>
           )}
+          {isOwner && room.status === "OPEN" && (
+            <>
+              {!canStart && (
+                <p className="muted small">All participants must be ready before the room can start.</p>
+              )}
+              <button className="primary" onClick={handleStart} disabled={busy || !canStart}>
+                {busy ? "Starting..." : "Start room"}
+              </button>
+            </>
+          )}
         </div>
+
+        {isOwner && room.status === "OPEN" && (
+          <div className="card sticker tilt-right">
+            <h2>Owner controls</h2>
+            <form className="form" onSubmit={handleSaveSettings}>
+              <label className="toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.locked}
+                  onChange={(e) => setSettings((current) => ({ ...current, locked: e.target.checked }))}
+                />
+                <span>Lock room to prevent new joins</span>
+              </label>
+              <label>
+                Max players
+                <select
+                  value={settings.maxMembers}
+                  onChange={(e) => setSettings((current) => ({ ...current, maxMembers: Number(e.target.value) }))}
+                >
+                  {[2, 3, 4].map((count) => (
+                    <option key={count} value={count}>{count}</option>
+                  ))}
+                </select>
+              </label>
+              <button className="primary" type="submit" disabled={busy}>
+                Save controls
+              </button>
+            </form>
+            <button className="ghost" onClick={handleRegenerateInvite} disabled={busy}>
+              Regenerate invite code
+            </button>
+          </div>
+        )}
 
         <div className="card sticker tilt-right">
           <h2>Your tasks</h2>


### PR DESCRIPTION
## Summary
- Add owner controls for locking rooms, regenerating invite codes, removing participants, and setting max players
- Add participant ready state before room start
- Require all participants to be ready before the owner can start the room
- Surface owner controls and ready status in the room UI